### PR TITLE
Add versioning, CHANGELOG, and CI/CD workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ajv-cli and validate samples
+        run: |
+          npm install -g ajv-cli
+          failed=0
+          for f in samples/*.json; do
+            echo "Validating $f..."
+            npx ajv-cli validate -s PureQL-Specification.json -d "$f" || failed=1
+          done
+          exit $failed
+
+      - name: Verify schema version matches tag
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          SCHEMA_VER=$(python3 -c "import json; print(json.load(open('PureQL-Specification.json')).get('version',''))")
+          if [ "$SCHEMA_VER" != "$TAG" ]; then
+            echo "ERROR: schema version '$SCHEMA_VER' does not match tag '$TAG'"
+            exit 1
+          fi
+
+      - name: Extract changelog notes
+        run: |
+          python3 - <<'PYEOF' > release_notes.txt
+          import re
+          import os
+
+          tag = os.environ["GITHUB_REF_NAME"]
+          content = open("CHANGELOG.md").read()
+          pattern = r"## \[" + re.escape(tag) + r"\][^\n]*\n(.*?)(?=\n## \[|\Z)"
+          m = re.search(pattern, content, re.DOTALL)
+          print(m.group(1).strip() if m else "No changelog entry found for this version.")
+          PYEOF
+
+      - name: Package samples
+        run: zip -r samples.zip samples/
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          PRERELEASE_FLAG=""
+          if [[ "$TAG" == *"-preview"* ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          gh release create "$TAG" \
+            --title "PureQL $TAG" \
+            --notes-file release_notes.txt \
+            $PRERELEASE_FLAG \
+            PureQL-Specification.json \
+            samples.zip \
+            CHANGELOG.md \
+            README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,15 +14,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install ajv-cli and validate samples
+      - name: Validate all samples against schema
         run: |
-          npm install -g ajv-cli
-          failed=0
-          for f in samples/*.json; do
-            echo "Validating $f..."
-            npx ajv-cli validate -s PureQL-Specification.json -d "$f" || failed=1
-          done
-          exit $failed
+          pip install jsonschema --quiet
+          python3 - <<'PYEOF'
+          import json, glob, sys
+          from jsonschema import Draft202012Validator
+
+          spec = json.load(open("PureQL-Specification.json"))
+          validator = Draft202012Validator(spec)
+          failed = False
+          for path in sorted(glob.glob("samples/*.json")):
+              doc = json.load(open(path))
+              errors = list(validator.iter_errors(doc))
+              if errors:
+                  print(f"FAIL {path}:")
+                  for e in errors:
+                      print(f"  {e.message}")
+                  failed = True
+              else:
+                  print(f"OK   {path}")
+          sys.exit(1 if failed else 0)
+          PYEOF
 
       - name: Verify schema version matches tag
         run: |
@@ -36,8 +49,7 @@ jobs:
       - name: Extract changelog notes
         run: |
           python3 - <<'PYEOF' > release_notes.txt
-          import re
-          import os
+          import re, os
 
           tag = os.environ["GITHUB_REF_NAME"]
           content = open("CHANGELOG.md").read()

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,23 @@
+name: Validate
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ajv-cli
+        run: npm install -g ajv-cli
+
+      - name: Validate all samples against schema
+        run: |
+          failed=0
+          for f in samples/*.json; do
+            echo "Validating $f..."
+            npx ajv-cli validate -s PureQL-Specification.json -d "$f" || failed=1
+          done
+          exit $failed

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,8 +1,9 @@
 name: Validate
 
 on:
-  push:
   pull_request:
+    branches:
+      - main
 
 jobs:
   validate:
@@ -10,14 +11,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install ajv-cli
-        run: npm install -g ajv-cli
-
       - name: Validate all samples against schema
         run: |
-          failed=0
-          for f in samples/*.json; do
-            echo "Validating $f..."
-            npx ajv-cli validate -s PureQL-Specification.json -d "$f" || failed=1
-          done
-          exit $failed
+          pip install jsonschema --quiet
+          python3 - <<'PYEOF'
+          import json, glob, sys
+          from jsonschema import Draft202012Validator
+
+          spec = json.load(open("PureQL-Specification.json"))
+          validator = Draft202012Validator(spec)
+          failed = False
+          for path in sorted(glob.glob("samples/*.json")):
+              doc = json.load(open(path))
+              errors = list(validator.iter_errors(doc))
+              if errors:
+                  print(f"FAIL {path}:")
+                  for e in errors:
+                      print(f"  {e.message}")
+                  failed = True
+              else:
+                  print(f"OK   {path}")
+          sys.exit(1 if failed else 0)
+          PYEOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to PureQL are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows Semantic Versioning with preview suffix `major.minor.patch-preview.major.minor.patch`.
+
+---
+
+## [0.1.0-preview.0.1.0] - 2026-05-20
+
+### Added
+- Initial preview release of the PureQL JSON Schema specification (draft 2020-12)
+- Core query structure: `from`, `select`, `where`, `joins`, `groupBy`, `having`, `orderBy`, `pagination`, `distinct`
+- Complete type system: scalar types (`string`, `number`, `boolean`, `null`, `date`, `time`, `datetime`, `uuid`) and their array variants
+- Expression types: field references, scalar literals, arithmetic operators, comparison operators, aggregate functions (`count`, `sum`, `avg`, `min`, `max`), and named parameters
+- Boolean logic: `and`, `or`, `not` composable predicates
+- Array equality for field-to-literal comparisons; single-value equality for aggregate/scalar comparisons
+- Range comparisons (`greaterThan`, `lessThan`, `greaterThanOrEqual`, `lessThanOrEqual`) for numeric, string, and date single-value expressions
+- Join support (`inner`, `left`, `right`, `full`) with array equality conditions
+- 12 reference sample queries covering the e-commerce domain (`users`, `orders`, `order_items`, `products`, `coupons`, `referrals`)

--- a/PureQL-Specification.json
+++ b/PureQL-Specification.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/kudima03/PureQL-Specification/releases/download/0.1.0-preview.0.1.0/PureQL-Specification.json",
+  "version": "0.1.0-preview.0.1.0",
   "definitions": {
     "arrayParameters": {
       "stringArrayParameter": {


### PR DESCRIPTION
## Summary

- Embeds `\$id` and `version` (`0.1.0-preview.0.1.0`) in `PureQL-Specification.json` for stable consumer reference URLs
- Adds `CHANGELOG.md` following Keep a Changelog format with preview versioning convention (`major.minor.patch-preview.major.minor.patch`)
- Adds CI workflow (`validate.yml`): validates all samples against the schema on every push and PR
- Adds CD workflow (`release.yml`): triggered on `*.*.*` tags — validates samples, checks schema `version` matches the tag, extracts changelog notes for the release body, then publishes a GitHub Release with `PureQL-Specification.json`, `samples.zip`, `CHANGELOG.md`, and `README.md` as assets; preview tags are marked as pre-release automatically

## Test plan

- [ ] Merge this PR then push tag `0.1.0-preview.0.1.0` — verify the release workflow creates a pre-release with all assets attached
- [ ] Verify CI runs and passes on this PR
- [ ] Verify schema version in the JSON matches the intended tag before tagging