### PR TITLE
rename integer_equality to number_equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Versioning follows Semantic Versioning with preview suffix `major.minor.patch-pr
 
 ---
 
+## [0.1.0-preview.0.4.0] - 2026-05-25
+
+Renames the internal `integer_equality` definition to `number_equality` for consistency with the `number` scalar type.
+
+Tracking issue: #28.
+
+### Changed
+
+- **`integer_equality` renamed to `number_equality`** in `definitions/equalities`. The `$ref` in `singleValueEquality` updated accordingly.
+
+---
+
 ## [0.1.0-preview.0.3.0] - 2026-05-25
 
 Adds the per-row arithmetic and date/datetime math operators to the `each*` family established in `0.2.0`. Together with the existing per-row boolean/comparison operators, this closes the gap that previously made per-row computed columns inexpressible (e.g. `unit_price * quantity AS subtotal`, `sum(unit_price * quantity)`, `order_date + 30 days`, `shipped_at - ordered_at > 48h`). Purely additive on top of `0.2.0`.

--- a/PureQL-Specification.json
+++ b/PureQL-Specification.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/kudima03/PureQL-Specification/releases/download/0.1.0-preview.0.3.0/PureQL-Specification.json",
-  "version": "0.1.0-preview.0.3.0",
+  "$id": "https://github.com/kudima03/PureQL-Specification/releases/download/0.1.0-preview.0.4.0/PureQL-Specification.json",
+  "version": "0.1.0-preview.0.4.0",
   "definitions": {
     "arrayParameters": {
       "stringArrayParameter": {

--- a/PureQL-Specification.json
+++ b/PureQL-Specification.json
@@ -2185,7 +2185,7 @@
           "$ref": "#/definitions/equalities/boolean_equality"
         },
         {
-          "$ref": "#/definitions/equalities/integer_equality"
+          "$ref": "#/definitions/equalities/number_equality"
         },
         {
           "$ref": "#/definitions/equalities/string_equality"
@@ -2448,7 +2448,7 @@
           }
         }
       },
-      "integer_equality": {
+      "number_equality": {
         "type": "object",
         "required": [
           "operator",


### PR DESCRIPTION
Closes #28. Renames the `integer_equality` definition to `number_equality` and updates the `$ref` accordingly.