### PR TITLE
add sort direction to orderBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Versioning follows Semantic Versioning with preview suffix `major.minor.patch-pr
 
 ---
 
+## [0.1.0-preview.0.5.0] - 2026-05-25
+
+Introduces sort direction control for `orderBy`. Previously `orderBy` accepted bare field references, making sort direction implementation-defined. Queries that used bare fields in `orderBy` must be migrated to the new `orderByItem` wrapper.
+
+Tracking issue: #27.
+
+### Added
+
+- **`orderByItem` definition** — object with required `field` (a `$ref` to `#/definitions/field`) and optional `direction` (`"asc"` | `"desc"`, default `"asc"`).
+
+### Changed
+
+- **`orderBy.items`** now references `orderByItem` instead of `field` directly. Bare field objects in `orderBy` are no longer valid; wrap each field in `{ "field": <field>, "direction": "asc" }`.
+
+---
+
 ## [0.1.0-preview.0.3.0] - 2026-05-25
 
 Adds the per-row arithmetic and date/datetime math operators to the `each*` family established in `0.2.0`. Together with the existing per-row boolean/comparison operators, this closes the gap that previously made per-row computed columns inexpressible (e.g. `unit_price * quantity AS subtotal`, `sum(unit_price * quantity)`, `order_date + 30 days`, `shipped_at - ordered_at > 48h`). Purely additive on top of `0.2.0`.

--- a/PureQL-Specification.json
+++ b/PureQL-Specification.json
@@ -2169,6 +2169,18 @@
         }
       }
     },
+    "orderByItem": {
+      "type": "object",
+      "required": ["field"],
+      "properties": {
+        "field": { "$ref": "#/definitions/field" },
+        "direction": {
+          "type": "string",
+          "enum": ["asc", "desc"],
+          "default": "asc"
+        }
+      }
+    },
     "equality": {
       "oneOf": [
         {
@@ -3236,7 +3248,7 @@
     "orderBy": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/field"
+        "$ref": "#/definitions/orderByItem"
       }
     },
     "pagination": {

--- a/PureQL-Specification.json
+++ b/PureQL-Specification.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/kudima03/PureQL-Specification/releases/download/0.1.0-preview.0.3.0/PureQL-Specification.json",
-  "version": "0.1.0-preview.0.3.0",
+  "$id": "https://github.com/kudima03/PureQL-Specification/releases/download/0.1.0-preview.0.5.0/PureQL-Specification.json",
+  "version": "0.1.0-preview.0.5.0",
   "definitions": {
     "arrayParameters": {
       "stringArrayParameter": {

--- a/README.md
+++ b/README.md
@@ -142,14 +142,15 @@ Each join specifies its type (`inner`, `left`, `right`, `full`), the entity to j
 
 ### `groupBy` / `orderBy`
 
-Both accept an array of field references.
+`groupBy` accepts an array of field references. `orderBy` accepts an array of `orderByItem` objects, each pairing a `field` with an optional `direction` (`"asc"` | `"desc"`, default `"asc"`).
 
 ```json
 "groupBy": [
   { "entity": "orders", "field": "user_id", "type": { "name": "uuid" } }
 ],
 "orderBy": [
-  { "entity": "users", "field": "name", "type": { "name": "string" } }
+  { "field": { "entity": "users", "field": "name", "type": { "name": "string" } }, "direction": "asc" },
+  { "field": { "entity": "orders", "field": "total", "type": { "name": "number" } }, "direction": "desc" }
 ]
 ```
 
@@ -481,7 +482,7 @@ The [`samples/`](samples/) directory contains query examples ordered by complexi
 | [`09_arithmetic.json`](samples/09_arithmetic.json) | `add`, `multiply`, `divide` on aggregate results |
 | [`10_parameters.json`](samples/10_parameters.json) | Named scalar parameters in per-row predicates |
 | [`11_distinct.json`](samples/11_distinct.json) | `distinct: true` to deduplicate results |
-| [`12_complex_query.json`](samples/12_complex_query.json) | Full query: joins, per-row `where`, groupBy, single-value `having`, arithmetic, parameters, orderBy, pagination |
+| [`12_complex_query.json`](samples/12_complex_query.json) | Full query: joins, per-row `where`, groupBy, single-value `having`, arithmetic, parameters, orderBy with direction, pagination |
 | [`13_range_filter.json`](samples/13_range_filter.json) | `eachGreaterThan` and `eachLessThan` combined with `eachAnd` |
 | [`14_each_field_to_field.json`](samples/14_each_field_to_field.json) | Per-row range comparison between two fields (no scalar threshold) |
 | [`15_each_not_equal.json`](samples/15_each_not_equal.json) | `eachNot` wrapping `eachEqual` — the idiom for "field ≠ literal" |

--- a/samples/12_complex_query.json
+++ b/samples/12_complex_query.json
@@ -113,7 +113,10 @@
     ]
   },
   "orderBy": [
-    { "entity": "users", "field": "name", "type": { "name": "string" } }
+    {
+      "field": { "entity": "users", "field": "name", "type": { "name": "string" } },
+      "direction": "asc"
+    }
   ],
   "pagination": { "skip": 0, "take": 25 }
 }


### PR DESCRIPTION
Closes #27. Introduces `orderByItem` wrapper with required `field` and optional `direction` ("asc" | "desc", default "asc"). Updates `orderBy.items` ref and migrates sample 12.